### PR TITLE
ci: Make auto-commit step resilient to concurrent pushes

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -20,8 +20,10 @@ jobs:
           template: "templates/README.md.tpl"
           writeTo: "profile/README.md"
 
-      - uses: stefanzweifel/git-auto-commit-action@v7.1.0
+      - name: Commit changes
+        id: auto-commit
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: stefanzweifel/git-auto-commit-action@v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -30,3 +32,21 @@ jobs:
           commit_user_name: "GitHub Actions Bot"
           commit_user_email: "actions@github.com"
           commit_author: "GitHub Actions Bot <actions@github.com>"
+          skip_push: true
+
+      - name: Push changes with retry
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && steps.auto-commit.outputs.changes_detected == 'true'
+        run: |
+          max_retries=3
+          for attempt in $(seq 1 $max_retries); do
+            echo "Push attempt $attempt of $max_retries"
+            if git push origin main; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Push failed, pulling with rebase and retrying..."
+            git pull --rebase origin main
+            sleep $((attempt * 2))
+          done
+          echo "Push failed after $max_retries attempts"
+          exit 1


### PR DESCRIPTION
## Summary

The `stefanzweifel/git-auto-commit-action` does not pull or rebase before pushing — this is a deliberate non-goal upstream (see the action's README → "Limitations & Gotchas"). When this workflow runs concurrently with other actors pushing unrelated changes to `main` (e.g. a different folder), the action's internal `git push` is rejected as non-fast-forward and the workflow fails, even though the changes do not conflict.

This PR switches the auto-commit step to `skip_push: true` and adds a small shell retry loop that does `git pull --rebase` between push attempts. The pattern is the same as the one already proven in the `EngineeringKiosk/podcast-metadata` workflows.

## Test plan

- [ ] YAML still parses (workflow file shows up correctly in the Actions tab after merge)
- [ ] On the next scheduled / dispatched run, the new "Push changes with retry" step runs only when `changes_detected == 'true'`
- [ ] Verify a push race resolves cleanly (manually inducible by dispatching this workflow while pushing an unrelated commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)